### PR TITLE
POGenerator does not generate vaild po string when break line after '\' charactor.

### DIFF
--- a/source/Karambolo.PO/POGenerator.cs
+++ b/source/Karambolo.PO/POGenerator.cs
@@ -156,6 +156,10 @@ namespace Karambolo.PO
 
             while ((startIndex = GetStringBreakIndex()) >= 0)
             {
+                if (_builder[startIndex - 1] == '\\')
+                {
+                    startIndex--;
+                }
                 _builder.Insert(startIndex, s_stringBreak);
                 _lineStartIndex = startIndex + s_stringBreak.Length;
                 _lineStartIndex--;


### PR DESCRIPTION
Please see 15740ba

> When below, po string is not vaild.
> ```c#
> var catalog = new POCatalog { Encoding = "UTF-8"};
> var key = new POKey("\"フェイトバインダー、よく戻った！\"", null, "data\\exported\\localized\\jp\\text\\conversations\\factionquestlines\\rebel\\fq_rb_arris_rebelpathintro.stringtable/1/DefaultText");
> var entry = new POSingularEntry(key) { Translation = "" };
> 
> catalog.Add(entry);
> 
> using (StreamWriter streamWriter = File.CreateText("test.po"))
> {
>     var generator = new POGenerator();
>     generator.Generate(streamWriter, catalog);
> 
> }
> using(StreamReader streamReader = new StreamReader("test.po"))
> {
>     var parser = new POParser();
>     var result = parser.Parse(streamReader);
>     if(result.Success)
>     {
>         var catalog2 = result.Catalog;
>     } else
>     {
>         var diagnostics = result.Diagnostics;
>     }
> }
> ```
> 
> Before fix, result is
> ```po
> msgid ""
> msgstr ""
> "Content-Transfer-Encoding: 8bit\n"
> "Content-Type: text/plain; charset=UTF-8\n"
> 
> msgctxt ""
> "data\\exported\\localized\\jp\\text\\conversations\\factionquestlines\\rebel\"
> "\fq_rb_arris_rebelpathintro.stringtable/1/DefaultText"
> msgid "\"フェイトバインダー、よく戻った！\""
> msgstr ""
> ```
> 
> After fix, result is
> ```po
> msgid ""
> msgstr ""
> "Content-Transfer-Encoding: 8bit\n"
> "Content-Type: text/plain; charset=UTF-8\n"
> 
> msgctxt ""
> "data\\exported\\localized\\jp\\text\\conversations\\factionquestlines\\rebel"
> "\\fq_rb_arris_rebelpathintro.stringtable/1/DefaultText"
> msgid "\"フェイトバインダー、よく戻った！\""
> msgstr ""
> ```