### PR TITLE
Makes parsing of \n configurable

### DIFF
--- a/source/Karambolo.PO/POComment.cs
+++ b/source/Karambolo.PO/POComment.cs
@@ -199,7 +199,7 @@ namespace Karambolo.PO
 
     public class POPreviousValueComment : POComment
     {
-        public static bool TryParse(string value, out POPreviousValueComment result)
+        public static bool TryParse(string value, out POPreviousValueComment result, bool environmentIndependentNewLine)
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
@@ -219,7 +219,7 @@ namespace Karambolo.PO
             if (index < 0 ||
                 (length = value.Length) < 2 || value[0] != '"' || value[length - 1] != '"' ||
                 (idKind = POKey.GetIdKind(idKindToken)) == POIdKind.Unknown ||
-                POString.Decode(sb = new StringBuilder(), value, 1, length - 2) >= 0)
+                POString.Decode(sb = new StringBuilder(), value, 1, length - 2, environmentIndependentNewLine) >= 0)
             {
                 result = null;
                 return false;
@@ -227,14 +227,6 @@ namespace Karambolo.PO
 
             result = new POPreviousValueComment { IdKind = idKind, Value = sb.ToString() };
             return true;
-        }
-
-        public static POPreviousValueComment Parse(string value)
-        {
-            return
-                TryParse(value, out POPreviousValueComment result) ?
-                result :
-                throw new FormatException(Resources.IncorrectFormat);
         }
 
         public POPreviousValueComment() : base(POCommentKind.PreviousValue) { }

--- a/source/Karambolo.PO/POString.cs
+++ b/source/Karambolo.PO/POString.cs
@@ -5,7 +5,7 @@ namespace Karambolo.PO
 {
     internal static class POString
     {
-        public static int Decode(StringBuilder builder, string source, int startIndex, int count)
+        public static int Decode(StringBuilder builder, string source, int startIndex, int count, bool environmentIndependentNewLine)
         {
             var endIndex = startIndex + count;
             for (; startIndex < endIndex; startIndex++)
@@ -29,7 +29,12 @@ namespace Karambolo.PO
                     case '\\': b.Append('\\'); return true;
                     case '"': b.Append('"'); return true;
                     case 't': b.Append('\t'); return true;
-                    case 'n': b.Append(Environment.NewLine); return true;
+                    case 'n':
+                        if (environmentIndependentNewLine)
+                            b.Append('\n');
+                        else
+                            b.Append(Environment.NewLine);
+                        return true;
                     default: return false;
                 }
             }


### PR DESCRIPTION
One can set `POParserSettings.ReadEnvironmentIndependentNewLine` to always read `\n` as is instead of using system-dependent `Environment.NewLine`.