### PR TITLE
Add key to argument exception message

### DIFF
--- a/source/Karambolo.PO/POCatalog.cs
+++ b/source/Karambolo.PO/POCatalog.cs
@@ -163,7 +163,15 @@ namespace Karambolo.PO
         protected override void InsertItem(int index, IPOEntry item)
         {
             CheckEntry(item);
-            base.InsertItem(index, item);
+
+            try
+            {
+                base.InsertItem(index, item);
+            }
+            catch (ArgumentException ae)
+            {
+                throw new ArgumentException(ae.Message + Environment.NewLine + "Key: " + item.Key, ae);
+            }
         }
 
         protected override void SetItem(int index, IPOEntry item)


### PR DESCRIPTION
Hello,

would it be possible to include key to the argument exception please?

Use case:
when there are duplicate keys present in parsed PO file the exception is thrown,
this change would help identify the duplicates.

Thank you
Best regards
Daniel Trubač