### PR TITLE
Added case for '\r'

### DIFF
--- a/source/Karambolo.PO/POString.cs
+++ b/source/Karambolo.PO/POString.cs
@@ -34,6 +34,7 @@ namespace Karambolo.PO
                     case '\\': b.Append('\\'); return true;
                     case '"': b.Append('"'); return true;
                     case 't': b.Append('\t'); return true;
+                    case 'r': return true;
                     case 'n': b.Append(newLine); return true;
                     default: return false;
                 }

--- a/source/Karambolo.PO/POString.cs
+++ b/source/Karambolo.PO/POString.cs
@@ -12,53 +12,69 @@ namespace Karambolo.PO
 
         public static int Decode(StringBuilder builder, string source, int startIndex, int count, string newLine)
         {
-            var endIndex = startIndex + count;
-            for (; startIndex < endIndex; startIndex++)
+            for (var endIndex = startIndex + count; startIndex < endIndex; startIndex++)
             {
                 var c = source[startIndex];
-                if (c == '\\')
-                    if (++startIndex < endIndex && TryDecodeEscapeSequence(builder, source[startIndex]))
-                        continue;
-                    else
-                        return startIndex - 1;
+                if (c != '\\')
+                {
+                    builder.Append(c);
+                    continue;
+                }
+                
+                if (++startIndex < endIndex)
+                {
+                    c = source[startIndex];
+                    switch (c)
+                    {
+                        case '\\':
+                        case '"':
+                            builder.Append(c);
+                            continue;
+                        case 't':
+                            builder.Append('\t');
+                            continue;
+                        case 'r':
+                            var index = startIndex;
+                            if (++index + 1 < endIndex && source[index] == '\\' && source[++index] == 'n')
+                                startIndex = index;
+                            // "\r" and "\r\n" are both accepted as new line
+                            goto case 'n';
+                        case 'n':
+                            builder.Append(newLine);
+                            continue;
+                    }
+                }
 
-                builder.Append(c);
+                // invalid escape sequence
+                return startIndex - 1;
             }
 
             return -1;
-
-            bool TryDecodeEscapeSequence(StringBuilder b, char c)
-            {
-                switch (c)
-                {
-                    case '\\': b.Append('\\'); return true;
-                    case '"': b.Append('"'); return true;
-                    case 't': b.Append('\t'); return true;
-                    case 'r': return true;
-                    case 'n': b.Append(newLine); return true;
-                    default: return false;
-                }
-            }
         }
 
         public static void Encode(StringBuilder builder, string source, int startIndex, int count)
         {
-            var endIndex = startIndex + count;
-            for (; startIndex < endIndex; startIndex++)
+            for (var endIndex = startIndex + count; startIndex < endIndex; startIndex++)
             {
                 var c = source[startIndex];
                 switch (c)
                 {
-                    case '\\': builder.Append('\\'); break;
-                    case '"': builder.Append('\\'); break;
-                    case '\t': builder.Append('\\'); c = 't'; break;
+                    case '\\':
+                    case '"':
+                        builder.Append('\\').Append(c);
+                        continue;
+                    case '\t':
+                        builder.Append('\\').Append('t');
+                        continue;
                     case '\r':
-                    case '\n':
                         var index = startIndex;
-                        if (c == '\r' && ++index < endIndex && source[index] == '\n')
+                        if (++index < endIndex && source[index] == '\n')
                             startIndex = index;
-
-                        builder.Append('\\'); c = 'n'; break;
+                        // "\r" and "\r\n" are encoded the same as "\n" to keep PO content platform-independent
+                        goto case '\n';
+                    case '\n':
+                        builder.Append('\\').Append('n');
+                        continue;
                 }
 
                 builder.Append(c);

--- a/test/Karambolo.PO.Test/POParserTest.cs
+++ b/test/Karambolo.PO.Test/POParserTest.cs
@@ -363,5 +363,28 @@ msgstr """"";
             Assert.Equal(1, result.Diagnostics[0].Args.Length);
             Assert.Equal(new TextLocation(0, 0), result.Diagnostics[0].Args[0]);
         }
+
+        [Fact]
+        public void Pr19_NonUnixLineTerminators()
+        {
+            var parser = new POParser(new POParserSettings
+            {
+                StringDecodingOptions = new POStringDecodingOptions { KeepKeyStringsPlatformIndependent = true }
+            });
+
+            var input =
+@"msgid ""Windows\r\nLine Terminator""
+msgstr ""\\r\rLine Terminator""
+";
+            POParseResult result = parser.Parse(input);
+
+            Assert.True(result.Success);
+            Assert.False(result.Diagnostics.HasWarning);
+
+            var catalog = result.Catalog;
+            var key = new POKey("Windows\nLine Terminator");
+            Assert.True(catalog.Contains(key));
+            Assert.Equal($"\\r{Environment.NewLine}Line Terminator", catalog[key][0]);
+        }
     }
 }


### PR DESCRIPTION
When trying to parse PO file with strings containing "\r\n" there's an error "Escape sequence is invalid at". But I believe it's a valid case, PO files can also be generated/used on Windows, hence I've added it.