### PR TITLE
Minor gettext compatibility fix

### DIFF
--- a/source/Karambolo.PO/POGenerator.cs
+++ b/source/Karambolo.PO/POGenerator.cs
@@ -193,8 +193,9 @@ namespace Karambolo.PO
                         case POCommentKind.PreviousValue: commentKindToken = '|'; break;
                         default: throw new InvalidOperationException();
                     }
+                    var separator = string.IsNullOrEmpty(comment.ToString()) ? string.Empty : " ";
 
-                    _writer.WriteLine($"#{commentKindToken} {comment}");
+                    _writer.WriteLine($"#{commentKindToken}{separator}{comment}");
                 }
         }
 


### PR DESCRIPTION
When a translator comment is empty, gettext writes a line containing `# `, whereas
Karambolo.PO would output `#  `. The behaviour is now more consistent.