### PR TITLE
Ensure validity of previous value comments

### DIFF
--- a/test/Karambolo.PO.Test/POGeneratorTest.cs
+++ b/test/Karambolo.PO.Test/POGeneratorTest.cs
@@ -59,8 +59,13 @@ namespace Karambolo.PO.Test
                 new POExtractedComment { Text = "some extracted comment" },
                 new POReferenceComment { References = new POSourceReference[] { new POSourceReference("/Views/Home/Index.cshtml", 8) } },
                 new POFlagsComment { Flags = new SortedSet<string> { "fuzzy", "csharp-format" } },
-                new POPreviousValueComment { IdKind = POIdKind.Id, Value = "{0} hour to midnite" },
+                // These entries should be reordered
+                new POPreviousValueComment { IdKind = POIdKind.ContextId, Value = "Previous Home" },
                 new POPreviousValueComment { IdKind = POIdKind.PluralId, Value = "{0} hours to midnite" },
+                new POPreviousValueComment { IdKind = POIdKind.Id, Value = "{0} hour to midnite" },
+                // These entries are expected to be dropped
+                new POPreviousValueComment { IdKind = POIdKind.ContextId, Value = "invalid comment (duplicate)" },
+                new POPreviousValueComment { IdKind = POIdKind.Unknown, Value = "invalid comment (unknown ID)" },
             };
             result.Add(entry);
 

--- a/test/Karambolo.PO.Test/POParserTest.cs
+++ b/test/Karambolo.PO.Test/POParserTest.cs
@@ -95,7 +95,7 @@ namespace Karambolo.PO.Test
 
             if (expectComments)
             {
-                Assert.Equal(6, catalog[key1].Comments.Count);
+                Assert.Equal(7, catalog[key1].Comments.Count);
                 Assert.Equal(0, catalog[key2].Comments.Count);
 
                 IList<POComment> comments = catalog[key1].Comments;
@@ -119,12 +119,16 @@ namespace Karambolo.PO.Test
                 Assert.Contains("csharp-format", flags);
 
                 Assert.Equal(POCommentKind.PreviousValue, comments[4].Kind);
-                Assert.Equal(POIdKind.Id, ((POPreviousValueComment)comments[4]).IdKind);
-                Assert.Equal("{0} hour to midnite", ((POPreviousValueComment)comments[4]).Value);
+                Assert.Equal(POIdKind.ContextId, ((POPreviousValueComment)comments[4]).IdKind);
+                Assert.Equal("Previous Home", ((POPreviousValueComment)comments[4]).Value);
 
                 Assert.Equal(POCommentKind.PreviousValue, comments[5].Kind);
-                Assert.Equal(POIdKind.PluralId, ((POPreviousValueComment)comments[5]).IdKind);
-                Assert.Equal("{0} hours to midnite", ((POPreviousValueComment)comments[5]).Value);
+                Assert.Equal(POIdKind.Id, ((POPreviousValueComment)comments[5]).IdKind);
+                Assert.Equal("{0} hour to midnite", ((POPreviousValueComment)comments[5]).Value);
+
+                Assert.Equal(POCommentKind.PreviousValue, comments[6].Kind);
+                Assert.Equal(POIdKind.PluralId, ((POPreviousValueComment)comments[6]).IdKind);
+                Assert.Equal("{0} hours to midnite", ((POPreviousValueComment)comments[6]).Value);
             }
             else
             {

--- a/test/Karambolo.PO.Test/Resources/sample.po
+++ b/test/Karambolo.PO.Test/Resources/sample.po
@@ -18,6 +18,7 @@ msgstr ""
 #. some extracted comment
 #: /Views/Home/Index.cshtml:8
 #, csharp-format, fuzzy
+#| msgctxt "Previous Home"
 #| msgid "{0} hour to midnite"
 #| msgid_plural "{0} hours to midnite"
 msgctxt "Home"

--- a/test/Karambolo.PO.Test/Resources/sample_withcustomheaderorder.po
+++ b/test/Karambolo.PO.Test/Resources/sample_withcustomheaderorder.po
@@ -18,6 +18,7 @@ msgstr ""
 #. some extracted comment
 #: /Views/Home/Index.cshtml:8
 #, csharp-format, fuzzy
+#| msgctxt "Previous Home"
 #| msgid "{0} hour to midnite"
 #| msgid_plural "{0} hours to midnite"
 msgctxt "Home"


### PR DESCRIPTION
Here is another seemingly undocumented GNU gettext rule that requires fixing: previous value comments must obey a very specific order (`msgctxt`, `msgid`, `msgid_plural`), and no other header is allowed to appear.

New checks have been added to the unit tests.

For the record, here are two examples of invalid `.po` files that Karambolo.PO may create in some circumstances:

```po
#| msgid "oldyo"
#| msgctxt "INVALID (wrong order)"
msgid "yo"
msgstr "yo!"
```

```po
#| msgctxt "old context"
#| msgid "oldyo"
#| msgid "INVALID (duplicate entry)"
msgid "yo"
msgstr "yo!"
```

The GNU gettext utility `msgcat` is a very convenient tool to check the validity of these files:

```cmd
% msgcat invalid.po
invalid.po:3:9: syntax error
msgcat: found 1 fatal error
%
```